### PR TITLE
Fix memory leaks.

### DIFF
--- a/src/food.c
+++ b/src/food.c
@@ -33,6 +33,12 @@ food_renew(Food *food)
 	mvwprintw(gameinfo.map, food->row, food->col, "%c", FOOD_CHAR);
 }
 
+void
+food_free(Food *food)
+{
+	free(food);
+}
+
 int
 food_get_row(const Food *f)
 {

--- a/src/food.h
+++ b/src/food.h
@@ -6,6 +6,7 @@ typedef struct _food Food;
 
 Food *food_new(void);
 void food_renew(Food *food);
+void food_free(Food *food);
 
 int food_get_row(const Food *f);
 int food_get_col(const Food *f);

--- a/src/gaming.c
+++ b/src/gaming.c
@@ -155,6 +155,7 @@ frame_end:
 
 game_end:
 	snake_free(snake);
+    food_free(food);
 
 	return ret;
 }

--- a/src/snake.c
+++ b/src/snake.c
@@ -72,6 +72,7 @@ snake_free(Snake *snake)
 		snake_node_free(node);
 		node = next;
 	}
+	free(snake);
 }
 
 void


### PR DESCRIPTION
Detected by valgrind. Report: 

```
{16-12-16 17:23}***:~/playground/c/sssnake@master✗✗✗✗✗✗ zhenghu% valgrind --tool=memcheck --leak-check=full ./debug
==5513== Memcheck, a memory error detector
==5513== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==5513== Using Valgrind-3.12.0 and LibVEX; rerun with -h for copyright info
==5513== Command: ./debug
==5513== 
==5513== 
==5513== HEAP SUMMARY:
==5513==     in use at exit: 1,143,266 bytes in 260 blocks
==5513==   total heap usage: 274 allocs, 14 frees, 1,156,156 bytes allocated
==5513== 
==5513== 8 bytes in 1 blocks are definitely lost in loss record 1 of 49
==5513==    at 0x4C2AB8D: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==5513==    by 0x4013D3: food_new (food.c:16)
==5513==    by 0x401BF3: gaming (gaming.c:90)
==5513==    by 0x401B00: gaming_main (gaming.c:51)
==5513==    by 0x400D7F: main (main.c:26)
==5513== 
==5513== 24 bytes in 1 blocks are definitely lost in loss record 7 of 49
==5513==    at 0x4C2AB8D: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==5513==    by 0x400E7F: snake_new (snake.c:40)
==5513==    by 0x401BDC: gaming (gaming.c:82)
==5513==    by 0x401B00: gaming_main (gaming.c:51)
==5513==    by 0x400D7F: main (main.c:26)
==5513== 
==5513== LEAK SUMMARY:
==5513==    definitely lost: 32 bytes in 2 blocks
==5513==    indirectly lost: 0 bytes in 0 blocks
==5513==      possibly lost: 0 bytes in 0 blocks
==5513==    still reachable: 1,143,234 bytes in 258 blocks
==5513==         suppressed: 0 bytes in 0 blocks
==5513== Reachable blocks (those to which a pointer was found) are not shown.
==5513== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==5513== 
==5513== For counts of detected and suppressed errors, rerun with: -v
==5513== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)

```